### PR TITLE
Encode default properties

### DIFF
--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
@@ -108,14 +108,14 @@ class KtoonConfigurationBuilder {
      * Controls whether properties whose values are equal to their declared default values are
      * written during serialization.
      *
-     * When `true` (default), all properties are encoded even if they currently hold the same
-     * value as their default. This makes the serialized output explicit and can simplify
-     * interoperability with consumers that do not know the schema or its default values, at the
-     * cost of a larger payload.
+     * When `true` (default), all properties are encoded even if they currently hold the same value
+     * as their default. This is usually what you want because the LLM does not know what the
+     * default values are.
      *
-     * When `false`, properties whose values match their defaults are omitted from the output.
-     * This reduces the size of the serialized data, but requires decoders to be aware of and
-     * reapply default values during deserialization.
+     * When `false`, properties whose values match their defaults are omitted from the output. This
+     * reduces the size of the serialized data. This allows you to strip out fields you don't want.
+     * Consider using the [kotlinx.serialization.EncodeDefault] annotation on specific properties
+     * instead for more fine-grained control.
      */
     var encodeDefaults: Boolean = true
 

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
@@ -12,6 +12,7 @@ package com.lukelast.ktoon
  * @property delimiter Delimiter character for array values and tabular format (default: COMMA)
  * @property indentSize Number of spaces per indentation level (default: 2)
  * @property sortFields Enable alphabetical sorting of object fields (default: false)
+ * @property encodeDefaults Enable encoding of default property values (default: true)
  */
 data class KtoonConfiguration(
     val strictMode: Boolean = true,
@@ -21,6 +22,7 @@ data class KtoonConfiguration(
     val delimiter: Delimiter = Delimiter.COMMA,
     val indentSize: Int = 2,
     val sortFields: Boolean = false,
+    val encodeDefaults: Boolean = true,
 ) {
     init {
         require(indentSize > 0) { "indentSize must be positive, got $indentSize" }
@@ -102,6 +104,9 @@ class KtoonConfigurationBuilder {
      */
     var sortFields: Boolean = false
 
+    /** Encode properties with default values. */
+    var encodeDefaults: Boolean = true
+
     fun build(): KtoonConfiguration =
         KtoonConfiguration(
             strictMode = strictMode,
@@ -111,5 +116,6 @@ class KtoonConfigurationBuilder {
             delimiter = delimiter,
             indentSize = indentSize,
             sortFields = sortFields,
+            encodeDefaults = encodeDefaults,
         )
 }

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/KtoonConfiguration.kt
@@ -104,7 +104,19 @@ class KtoonConfigurationBuilder {
      */
     var sortFields: Boolean = false
 
-    /** Encode properties with default values. */
+    /**
+     * Controls whether properties whose values are equal to their declared default values are
+     * written during serialization.
+     *
+     * When `true` (default), all properties are encoded even if they currently hold the same
+     * value as their default. This makes the serialized output explicit and can simplify
+     * interoperability with consumers that do not know the schema or its default values, at the
+     * cost of a larger payload.
+     *
+     * When `false`, properties whose values match their defaults are omitted from the output.
+     * This reduces the size of the serialized data, but requires decoders to be aware of and
+     * reapply default values during deserialization.
+     */
     var encodeDefaults: Boolean = true
 
     fun build(): KtoonConfiguration =

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ElementCapturer.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ElementCapturer.kt
@@ -38,7 +38,7 @@ internal class ElementCapturer(
             config.delimiter.char,
         )
 
-    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = false
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = true
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         currentIndex = index

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ElementCapturer.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ElementCapturer.kt
@@ -38,7 +38,8 @@ internal class ElementCapturer(
             config.delimiter.char,
         )
 
-    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = true
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) =
+        config.encodeDefaults
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         currentIndex = index

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonMapEncoder.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonMapEncoder.kt
@@ -22,6 +22,11 @@ internal class ToonMapEncoder(
     private var currentKey: String? = null
     private var isKey = true
 
+    /**
+     * Maps always encode all entries — unlike class properties, map entries don't have "default
+     * values" in the serialization sense. An entry either exists or it doesn't. The
+     * [KtoonConfiguration.encodeDefaults] config applies to class properties with declared defaults.
+     */
     override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = true
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonObjectEncoder.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonObjectEncoder.kt
@@ -36,7 +36,8 @@ internal class ToonObjectEncoder(
     private val writer: ToonWriter
         get() = fieldWriter ?: rawWriter
 
-    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = true
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) =
+        config.encodeDefaults
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         elementIndex = index

--- a/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonObjectEncoder.kt
+++ b/ktoon/src/commonMain/kotlin/com/lukelast/ktoon/encoding/ToonObjectEncoder.kt
@@ -36,7 +36,7 @@ internal class ToonObjectEncoder(
     private val writer: ToonWriter
         get() = fieldWriter ?: rawWriter
 
-    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = false
+    override fun shouldEncodeElementDefault(descriptor: SerialDescriptor, index: Int) = true
 
     override fun encodeElement(descriptor: SerialDescriptor, index: Int): Boolean {
         elementIndex = index

--- a/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsNullTest.kt
+++ b/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsNullTest.kt
@@ -1,0 +1,98 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package com.lukelast.ktoon
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KtoonEncodeDefaultsNullTest {
+
+    @Test
+    fun `encodeDefaults=true + ALWAYS + default`() =
+        assertCase(true, AlwaysDefaultNull(), line(NULL_LITERAL))
+
+    @Test
+    fun `encodeDefaults=true + ALWAYS + non-default`() =
+        assertCase(true, AlwaysDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + ALWAYS + default`() =
+        assertCase(false, AlwaysDefaultNull(), line(NULL_LITERAL))
+
+    @Test
+    fun `encodeDefaults=false + ALWAYS + non-default`() =
+        assertCase(false, AlwaysDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + NEVER + default`() = assertCase(true, NeverDefaultNull(), omit)
+
+    @Test
+    fun `encodeDefaults=true + NEVER + non-default`() =
+        assertCase(true, NeverDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + NEVER + default`() = assertCase(false, NeverDefaultNull(), omit)
+
+    @Test
+    fun `encodeDefaults=false + NEVER + non-default`() =
+        assertCase(false, NeverDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + PLAIN + default`() = assertCase(true, PlainDefaultNull(), line(NULL_LITERAL))
+
+    @Test
+    fun `encodeDefaults=true + PLAIN + non-default`() =
+        assertCase(true, PlainDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + PLAIN + default`() = assertCase(false, PlainDefaultNull(), omit)
+
+    @Test
+    fun `encodeDefaults=false + PLAIN + non-default`() =
+        assertCase(false, PlainDefaultNull(CUSTOM_VALUE), line(CUSTOM_VALUE))
+
+    private inline fun <reified T> assertCase(
+        encodeDefaults: Boolean,
+        value: T,
+        expected: Expected,
+    ) {
+        val ktoon = Ktoon { this.encodeDefaults = encodeDefaults }
+        val encoded = ktoon.encodeToString(value)
+        val expectedText =
+            when (expected) {
+                is Expected.Line -> "value: ${expected.value}"
+                Expected.Omit -> ""
+            }
+        assertEquals(expectedText, encoded)
+        val decoded = ktoon.decodeFromString<T>(encoded)
+        assertEquals(value, decoded)
+    }
+}
+
+private const val CUSTOM_VALUE = "custom"
+private const val NULL_LITERAL = "null"
+
+private sealed interface Expected {
+    data class Line(val value: String) : Expected
+
+    object Omit : Expected
+}
+
+private fun line(value: String) = Expected.Line(value)
+
+private val omit = Expected.Omit
+
+@Serializable
+private data class AlwaysDefaultNull(
+    @EncodeDefault(Mode.ALWAYS) val value: String? = null,
+)
+
+@Serializable
+private data class NeverDefaultNull(
+    @EncodeDefault(Mode.NEVER) val value: String? = null,
+)
+
+@Serializable private data class PlainDefaultNull(val value: String? = null)

--- a/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsTest.kt
+++ b/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsTest.kt
@@ -1,0 +1,80 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package com.lukelast.ktoon
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class KtoonEncodeDefaultsTest {
+
+    @Test
+    fun `encodeDefaults=true + ALWAYS + default`() =
+        assertCase(true, AlwaysDefault(), expected(DEFAULT_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + ALWAYS + non-default`() =
+        assertCase(true, AlwaysDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + ALWAYS + default`() =
+        assertCase(false, AlwaysDefault(), expected(DEFAULT_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + ALWAYS + non-default`() =
+        assertCase(false, AlwaysDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + NEVER + default`() = assertCase(true, NeverDefault(), expected(null))
+
+    @Test
+    fun `encodeDefaults=true + NEVER + non-default`() =
+        assertCase(true, NeverDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + NEVER + default`() =
+        assertCase(false, NeverDefault(), expected(null))
+
+    @Test
+    fun `encodeDefaults=false + NEVER + non-default`() =
+        assertCase(false, NeverDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + PLAIN + default`() =
+        assertCase(true, PlainDefault(), expected(DEFAULT_VALUE))
+
+    @Test
+    fun `encodeDefaults=true + PLAIN + non-default`() =
+        assertCase(true, PlainDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    @Test
+    fun `encodeDefaults=false + PLAIN + default`() =
+        assertCase(false, PlainDefault(), expected(null))
+
+    @Test
+    fun `encodeDefaults=false + PLAIN + non-default`() =
+        assertCase(false, PlainDefault(CUSTOM_VALUE), expected(CUSTOM_VALUE))
+
+    private inline fun <reified T> assertCase(encodeDefaults: Boolean, value: T, expected: String) {
+        val ktoon = Ktoon { this.encodeDefaults = encodeDefaults }
+        val encoded = ktoon.encodeToString(value)
+        assertEquals(expected, encoded)
+        val decoded = ktoon.decodeFromString<T>(encoded)
+        assertEquals(value, decoded)
+    }
+
+    private fun expected(value: String?): String = value?.let { "value: $it" } ?: ""
+}
+
+private const val DEFAULT_VALUE = "default"
+private const val CUSTOM_VALUE = "custom"
+
+@Serializable
+private data class AlwaysDefault(@EncodeDefault(Mode.ALWAYS) val value: String = DEFAULT_VALUE)
+
+@Serializable
+private data class NeverDefault(@EncodeDefault(Mode.NEVER) val value: String = DEFAULT_VALUE)
+
+@Serializable private data class PlainDefault(val value: String = DEFAULT_VALUE)

--- a/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodingTest.kt
+++ b/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodingTest.kt
@@ -1,9 +1,9 @@
 package com.lukelast.ktoon
 
 import kotlinx.serialization.Serializable
+import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.Test
 
 class KtoonEncodingTest {
 

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/Runner.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/Runner.kt
@@ -92,4 +92,6 @@ abstract class Runner {
 val jsonPretty = Json {
     prettyPrint = true
     prettyPrintIndent = "  "
+    encodeDefaults = true
+    explicitNulls = true
 }

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
@@ -17,7 +17,7 @@ class Test33 : Runner() {
 }
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class DefaultsData  constructor(
+data class DefaultsData(
     val title: String = "Default Title",
     val name: String = "Default Name",
     val description: String = "Default Description",

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
@@ -1,0 +1,79 @@
+package com.lukelast.ktoon.data1.test33
+
+import com.lukelast.ktoon.data1.Runner
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+
+/**
+ * Test33: Default values and overrides Tests encoding/decoding when properties have defaults:
+ * - Default values are omitted when not overridden
+ * - Non-default values are encoded explicitly Expected: Decoding restores defaults for missing
+ *   fields
+ */
+class Test33 : Runner() {
+    override fun run() = doTest(data)
+}
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class DefaultsData  constructor(
+    val title: String = "Default Title",
+    val name: String = "Default Name",
+    val description: String = "Default Description",
+    val defaultNullSetToNull: Int? = null,
+    val defaultNullSetToOne: Int? = null,
+    val defaultOneSetToNull: Int? = 1,
+    val defaultOneSetToOne: Int? = 1,
+    @EncodeDefault(Mode.NEVER)
+    val defaultNullSetToNullModeNever: Int? = null,
+    @EncodeDefault(Mode.NEVER)
+    val defaultNullSetToOneModeNever: Int? = null,
+    @EncodeDefault(Mode.NEVER)
+    val defaultOneSetToNullModeNever: Int? = 1,
+    @EncodeDefault(Mode.NEVER)
+    val defaultOneSetToOneModeNever: Int? = 1,
+    @EncodeDefault(Mode.ALWAYS)
+    val defaultNullSetToNullModeAlways: Int? = null,
+    @EncodeDefault(Mode.ALWAYS)
+    val defaultNullSetToOneModeAlways: Int? = null,
+    @EncodeDefault(Mode.ALWAYS)
+    val defaultOneSetToNullModeAlways: Int? = 1,
+    @EncodeDefault(Mode.ALWAYS)
+    val defaultOneSetToOneModeAlways: Int? = 1,
+    val owner: Owner = Owner(),
+    val members: List<Member> = emptyList(),
+)
+
+@Serializable
+data class Owner(val name: String = "system", val email: String? = null, val team: String? = "core")
+
+@Serializable
+data class Member(
+    val id: Int,
+    val role: String = "viewer",
+    val active: Boolean = true,
+)
+
+val data =
+    DefaultsData(
+        title = "Non Default Title",
+        description = "Default Description",
+        defaultNullSetToNull = null,
+        defaultNullSetToOne = 1,
+        defaultOneSetToNull = null,
+        defaultOneSetToOne = 1,
+        defaultNullSetToNullModeNever = null,
+        defaultNullSetToOneModeNever = 1,
+        defaultOneSetToNullModeNever = null,
+        defaultOneSetToOneModeNever = 1,
+        defaultNullSetToNullModeAlways = null,
+        defaultNullSetToOneModeAlways = 1,
+        defaultOneSetToNullModeAlways = null,
+        defaultOneSetToOneModeAlways = 1,
+        members =
+            listOf(
+                Member(id = 1),
+                Member(id = 2, role = "admin", active = false),
+            ),
+    )

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/data.json
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/data.json
@@ -1,0 +1,32 @@
+{
+  "title": "Non Default Title",
+  "name": "Default Name",
+  "description": "Default Description",
+  "defaultNullSetToNull": null,
+  "defaultNullSetToOne": 1,
+  "defaultOneSetToNull": null,
+  "defaultOneSetToOne": 1,
+  "defaultNullSetToOneModeNever": 1,
+  "defaultOneSetToNullModeNever": null,
+  "defaultNullSetToNullModeAlways": null,
+  "defaultNullSetToOneModeAlways": 1,
+  "defaultOneSetToNullModeAlways": null,
+  "defaultOneSetToOneModeAlways": 1,
+  "owner": {
+    "name": "system",
+    "email": null,
+    "team": "core"
+  },
+  "members": [
+    {
+      "id": 1,
+      "role": "viewer",
+      "active": true
+    },
+    {
+      "id": 2,
+      "role": "admin",
+      "active": false
+    }
+  ]
+}

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/data.toon
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/data.toon
@@ -1,0 +1,20 @@
+title: Non Default Title
+name: Default Name
+description: Default Description
+defaultNullSetToNull: null
+defaultNullSetToOne: 1
+defaultOneSetToNull: null
+defaultOneSetToOne: 1
+defaultNullSetToOneModeNever: 1
+defaultOneSetToNullModeNever: null
+defaultNullSetToNullModeAlways: null
+defaultNullSetToOneModeAlways: 1
+defaultOneSetToNullModeAlways: null
+defaultOneSetToOneModeAlways: 1
+owner:
+  name: system
+  email: null
+  team: core
+members[2]{id,role,active}:
+  1,viewer,true
+  2,admin,false

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysNestedEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysNestedEncodeTest.kt
@@ -1,6 +1,9 @@
 package com.lukelast.ktoon.fixtures.encode
 
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlin.test.Ignore
@@ -54,9 +57,11 @@ class ArraysNestedEncodeTest {
         runFixtureEncodeTest<List<Item>>(fixture)
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `encodes root-level array of non-uniform objects in list format`() {
-        @Serializable data class Item(val id: Int, val name: String? = null)
+        @Serializable
+        data class Item(val id: Int, @EncodeDefault(Mode.NEVER) val name: String? = null)
 
         runFixtureEncodeTest<List<Item>>(fixture)
     }

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysObjectsEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysObjectsEncodeTest.kt
@@ -1,6 +1,9 @@
 package com.lukelast.ktoon.fixtures.encode
 
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlin.test.Ignore
@@ -14,9 +17,15 @@ class ArraysObjectsEncodeTest {
 
     private val fixture = "arrays-objects"
 
+    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `uses list format for objects with different fields`() {
-        @Serializable data class Item(val id: Int, val name: String, val extra: Boolean? = null)
+        @Serializable
+        data class Item(
+            val id: Int,
+            val name: String,
+            @EncodeDefault(Mode.NEVER) val extra: Boolean? = null,
+        )
 
         @Serializable data class Root(val items: List<Item>)
 
@@ -72,9 +81,11 @@ class ArraysObjectsEncodeTest {
         runFixtureEncodeTest<Root>(fixture)
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `uses list format for nested object arrays with mismatched keys`() {
-        @Serializable data class User(val id: Int, val name: String? = null)
+        @Serializable
+        data class User(val id: Int, @EncodeDefault(Mode.NEVER) val name: String? = null)
 
         @Serializable data class Item(val users: List<User>, val status: String)
 

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/KeyFoldingEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/KeyFoldingEncodeTest.kt
@@ -1,6 +1,9 @@
 package com.lukelast.ktoon.fixtures.encode
 
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.EncodeDefault.Mode
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -130,9 +133,10 @@ class KeyFoldingEncodeTest {
         runFixtureEncodeTest<Root>(fixture)
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `encodes folded chain ending with empty object`() {
-        @Serializable data class C(val d: Unit? = null)
+        @Serializable data class C(@EncodeDefault(Mode.NEVER) val d: Unit? = null)
         @Serializable data class B(val c: C)
 
         @Serializable data class A(val b: B)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes TOON serialization output by defaulting to encoding properties with declared default values, which may affect wire-format compatibility and fixture expectations. Core encoder behavior is touched (object/array capture paths), so regressions could surface in nested/annotated models despite added tests.
> 
> **Overview**
> Adds `KtoonConfiguration.encodeDefaults` (and builder DSL support) to control whether properties equal to their declared defaults are serialized, defaulting to **on**.
> 
> Plumbs this through encoding by honoring the flag in `ToonObjectEncoder` and `ElementCapturer` while explicitly keeping maps always fully encoded, and expands test coverage (including `@EncodeDefault` interactions and null defaults) plus a new `data1` fixture (`test33`) to validate round-trip behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c87e76cb072c8b1924646a76a036d640e9723091. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->