### PR TITLE
Remove ExperimentalSerializationApi opt-ins from tests

### DIFF
--- a/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsNullTest.kt
+++ b/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsNullTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
-
 package com.lukelast.ktoon
 
 import kotlinx.serialization.EncodeDefault

--- a/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsTest.kt
+++ b/ktoon/src/commonTest/kotlin/com/lukelast/ktoon/KtoonEncodeDefaultsTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
-
 package com.lukelast.ktoon
 
 import kotlinx.serialization.EncodeDefault

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/Runner.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/Runner.kt
@@ -9,7 +9,6 @@ import kotlin.io.path.isReadable
 import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlin.test.assertEquals
 import kotlin.test.Test
@@ -88,7 +87,6 @@ abstract class Runner {
     }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 val jsonPretty = Json {
     prettyPrint = true
     prettyPrintIndent = "  "

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/data1/test33/Test33.kt
@@ -3,7 +3,6 @@ package com.lukelast.ktoon.data1.test33
 import com.lukelast.ktoon.data1.Runner
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.EncodeDefault.Mode
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 
 /**
@@ -15,7 +14,6 @@ import kotlinx.serialization.Serializable
 class Test33 : Runner() {
     override fun run() = doTest(data)
 }
-@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class DefaultsData(
     val title: String = "Default Title",

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysNestedEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysNestedEncodeTest.kt
@@ -3,7 +3,6 @@ package com.lukelast.ktoon.fixtures.encode
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.EncodeDefault.Mode
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlin.test.Ignore
@@ -57,7 +56,6 @@ class ArraysNestedEncodeTest {
         runFixtureEncodeTest<List<Item>>(fixture)
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `encodes root-level array of non-uniform objects in list format`() {
         @Serializable

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysObjectsEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/ArraysObjectsEncodeTest.kt
@@ -3,7 +3,6 @@ package com.lukelast.ktoon.fixtures.encode
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.EncodeDefault.Mode
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
 import kotlin.test.Ignore
@@ -17,7 +16,6 @@ class ArraysObjectsEncodeTest {
 
     private val fixture = "arrays-objects"
 
-    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `uses list format for objects with different fields`() {
         @Serializable
@@ -81,7 +79,6 @@ class ArraysObjectsEncodeTest {
         runFixtureEncodeTest<Root>(fixture)
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `uses list format for nested object arrays with mismatched keys`() {
         @Serializable

--- a/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/KeyFoldingEncodeTest.kt
+++ b/ktoon/src/jvmTest/kotlin/com/lukelast/ktoon/fixtures/encode/KeyFoldingEncodeTest.kt
@@ -3,7 +3,6 @@ package com.lukelast.ktoon.fixtures.encode
 import com.lukelast.ktoon.fixtures.runFixtureEncodeTest
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.EncodeDefault.Mode
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.test.Test
@@ -133,7 +132,6 @@ class KeyFoldingEncodeTest {
         runFixtureEncodeTest<Root>(fixture)
     }
 
-    @OptIn(ExperimentalSerializationApi::class)
     @Test
     fun `encodes folded chain ending with empty object`() {
         @Serializable data class C(@EncodeDefault(Mode.NEVER) val d: Unit? = null)


### PR DESCRIPTION
Remove @OptIn and file-level OptIn annotations and related imports for kotlinx.serialization.ExperimentalSerializationApi from multiple test files. Clean up redundant opt-ins now that the experimental serialization opt-in is no longer required in these tests